### PR TITLE
[INFINITY-2375] Update postUninstallNotes for version 1.10

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,7 +1,6 @@
 ---
-post_title: Uninstalling
+post_title: Uninstall
 menu_order: 30
-post_excerpt: ""
 enterprise: 'no'
 ---
 
@@ -13,10 +12,10 @@ If you are using DC/OS 1.10 and the installed service has a version greater than
 
 1. Uninstall the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> beta-confluent-kafka`.
 
-For example, to uninstall a Kafka instance named `confluent-kafka-dev`, run:
+For example, to uninstall a Confluent Kafka instance named `kafka-dev`, run:
 
 ```bash
-dcos package uninstall --app-id=confluent-kafka-dev beta-confluent-kafka
+$ dcos package uninstall --app-id=kafka-dev beta-confluent-kafka
 ```
 
 ### Older versions
@@ -24,14 +23,14 @@ dcos package uninstall --app-id=confluent-kafka-dev beta-confluent-kafka
 If you are running DC/OS 1.9 or older, or a version of the service that is older than 2.0.0-x, follow these steps:
 
 1. Stop the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> <packagename>`.
-   For example, `dcos package uninstall --app-id=confluent-kafka-dev beta-confluent-kafka`.
+   For example, `dcos package uninstall --app-id=kafka-dev beta-confluent-kafka`.
 1. Clean up remaining reserved resources with the framework cleaner script, `janitor.py`. See [DC/OS documentation](https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner) for more information about the framework cleaner script.
 
-For example, to uninstall a Kafka instance named `confluent-kakfa-dev`, run:
+For example, to uninstall a Confluent Kafka instance named `kakfa-dev`, run:
 
 ```bash
-$ MY_SERVICE_NAME=confluent-kafka-dev
-$ dcos package uninstall --app-id=$MY_SERVICE_NAME beta-confluent-kafka`.
+$ MY_SERVICE_NAME=kafka-dev
+$ dcos package uninstall --app-id=$MY_SERVICE_NAME beta-confluent-kafka`
 $ dcos node ssh --master-proxy --leader "docker run mesosphere/janitor /janitor.py \
     -r $MY_SERVICE_NAME-role \
     -p $MY_SERVICE_NAME-principal \

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -12,7 +12,7 @@ If you are using DC/OS 1.10 and the installed service has a version greater than
 
 1. Uninstall the service. From the DC/OS CLI, enter `dcos package uninstall --app-id=<instancename> beta-confluent-kafka`.
 
-For example, to uninstall a Confluent Kafka instance named `kafka-dev`, run:
+For example, to uninstall an Apache Kafka by Confluent instance named `kafka-dev`, run:
 
 ```bash
 $ dcos package uninstall --app-id=kafka-dev beta-confluent-kafka
@@ -26,7 +26,7 @@ If you are running DC/OS 1.9 or older, or a version of the service that is older
    For example, `dcos package uninstall --app-id=kafka-dev beta-confluent-kafka`.
 1. Clean up remaining reserved resources with the framework cleaner script, `janitor.py`. See [DC/OS documentation](https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner) for more information about the framework cleaner script.
 
-For example, to uninstall a Confluent Kafka instance named `kakfa-dev`, run:
+For example, to uninstall an Apache Kafka by Confluent instance named `kakfa-dev`, run:
 
 ```bash
 $ MY_SERVICE_NAME=kafka-dev

--- a/universe/package.json
+++ b/universe/package.json
@@ -8,7 +8,7 @@
   "packagingVersion": "4.0",
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere and Confluent before deploying this beta candidate service. Product support is available to approved participants in the beta test program. Mutual Mesosphere and Confluent customers are eligible to participate in the beta program.  Contact your rep at either company or partner-support@confluent.io.",
   "postInstallNotes": "Apache Kafka by Confluent is being installed.\n\n\tDocumentation: {{documentation-path}}\n\tCommunity Support: {{issues-path}}",
-  "postUninstallNotes": "Apache Kafka by Confluent has been uninstalled.\nPlease follow the instructions at https://docs.mesosphere.com/current/usage/service-guides/kafka/uninstall to remove any persistent state if required.",
+  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/v2.0.0-0.11.0/uninstall/ to remove any persistent state if required.",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/universe/package.json
+++ b/universe/package.json
@@ -8,7 +8,7 @@
   "packagingVersion": "4.0",
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere and Confluent before deploying this beta candidate service. Product support is available to approved participants in the beta test program. Mutual Mesosphere and Confluent customers are eligible to participate in the beta program.  Contact your rep at either company or partner-support@confluent.io.",
   "postInstallNotes": "Apache Kafka by Confluent is being installed.\n\n\tDocumentation: {{documentation-path}}\n\tCommunity Support: {{issues-path}}",
-  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/v2.0.0-0.11.0/uninstall/ to remove any persistent state if required.",
+  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/confluent-kafka/v2.0.0.1-3.3.0e/uninstall/ to remove any persistent state if required.",
   "licenses": [
     {
       "name": "Apache License v2",


### PR DESCRIPTION
This is a PR that updates the postInstallNote for Confluent as in mesosphere/dcos-commons#1643.

I have also updated the confluent uninstall docs to match those of Kafka.